### PR TITLE
Improve warning testing for bad patterns

### DIFF
--- a/test/setup.jl
+++ b/test/setup.jl
@@ -52,11 +52,3 @@ function clear_vars!(ENV)
     delete!(ENV, "JULIA_SSH_NO_VERIFY_HOSTS")
 end
 
-function without_warnings(body::Function)
-    log_level = Logging.min_enabled_level(current_logger())
-    disable_logging(Logging.Warn)
-    try body()
-    finally
-        disable_logging(log_level-1)
-    end
-end


### PR DESCRIPTION
`disable_logging()` manipulates a global setting so it may interfere with
any other concurrent tests.  Instead, use the `@test_logs` macro to
capture logs (which internally uses `with_logger`).

I've also chosen to specifically test that a warning is produced here
(rather than just use `@test_logs min_level=Error` which would be more
like `without_warnings()`).

CC @keno I assume this may fix the problems you're seeing in `Base` tests. I don't actually know what they were :-)