### PR TITLE
JULIA_ALWAYS_VERIFY_HOSTS: pattern for hosts to always verify

### DIFF
--- a/.ci/change-uuid.jl
+++ b/.ci/change-uuid.jl
@@ -1,0 +1,5 @@
+using UUIDs
+
+project_filename = joinpath(dirname(@__DIR__), "Project.toml")
+
+write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"$(uuid4())\"\n"))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.3'
+          - '1' # automatically expands to the latest stable 1.x release of Julia.
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        arch:
+          - x64
+          - x86
+        # 32-bit Julia binaries are not available on macOS
+        exclude:
+          - os: macOS-latest
+            arch: x86
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-${{ matrix.os }}
+            ${{ runner.os }}-
+      - run: julia --color=yes .ci/change-uuid.jl
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/src/verify_host.jl
+++ b/src/verify_host.jl
@@ -24,6 +24,7 @@ variables depending on whether `transport` is supplied and what its value is:
 - `JULIA_NO_VERIFY_HOSTS` — hosts that should not be verified for any transport
 - `JULIA_SSL_NO_VERIFY_HOSTS` — hosts that should not be verified for SSL/TLS
 - `JULIA_SSH_NO_VERIFY_HOSTS` — hosts that should not be verified for SSH
+- `JULIA_ALWAYS_VERIFY_HOSTS` — hosts that should always be verified
 
 The values of each of these variables is a comma-separated list of host name
 patterns with the following syntax — each pattern is split on `.` into parts and
@@ -48,16 +49,14 @@ value; a `**` pattern matches any number of host name components. For example:
   `v1.api.example.com`
 - `**.example.com` matches any domain under `example.com`, including
   `example.com` itself, `api.example.com` and `v1.api.example.com`
-```
 """
 function verify_host(
     url :: AbstractString,
     transport :: Union{AbstractString, Nothing} = nothing,
 )
     host = url_host(url)
-    if env_host_pattern_match("JULIA_NO_VERIFY_HOSTS", host)
-        return false # don't verify
-    end
+    env_host_pattern_match("JULIA_ALWAYS_VERIFY_HOSTS", host) && return true
+    env_host_pattern_match("JULIA_NO_VERIFY_HOSTS", host) && return false
     transport = transport === nothing ? nothing : uppercase(transport)
     return if transport in ("SSL", "TLS")
         !env_host_pattern_match("JULIA_SSL_NO_VERIFY_HOSTS", host)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,6 +155,30 @@ end
         end
         clear_env()
     end
+
+    @testset "transparent proxy" begin
+        ENV["JULIA_ALWAYS_VERIFY_HOSTS"] = "**.example.com"
+        ENV["JULIA_SSL_NO_VERIFY_HOSTS"] = "**"
+        verified_hosts = [
+            "example.com",
+            "Example.COM",
+            "sub.eXampLe.cOm",
+            "123.sub.example.COM",
+        ]
+        unverified_hosts = [
+            "com",
+            "invalid",
+            "github.com",
+            "julialang.org",
+            "pkg.julialang.org",
+        ]
+        all_hosts = [verified_hosts .=> true; unverified_hosts .=> false]
+        for transport in TRANSPORTS, (host, tls_verified) in all_hosts
+            verified = tls_verified || transport ∉ ["tls", "ssl"]
+            @test verify_host(host, transport) == verified
+        end
+        clear_env()
+    end
 end
 
 reset_env()

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -53,6 +53,7 @@ const VARIABLES = [
     "JULIA_NO_VERIFY_HOSTS"
     "JULIA_SSH_NO_VERIFY_HOSTS"
     "JULIA_SSL_NO_VERIFY_HOSTS"
+    "JULIA_ALWAYS_VERIFY_HOSTS"
 ]
 
 const SAVED_VARS = Dict{String,Union{String,Nothing}}(


### PR DESCRIPTION
This seems useful for situations where only external connections are transparently proxied and internal connections should behave normally. It doesn't seem necessary to have separate variables for different protocols here but that could be added in the future if it turns out to be useful.