### PR TITLE
ca_roots: empty JULIA_SSL_CA_ROOTS_PATH ignores SSL_CERT_{FILE,DIR}

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ path to the set of root certificates that are bundled with Julia is returned.
 The default value returned by `ca_roots()` may be overridden by setting the
 `JULIA_SSL_CA_ROOTS_PATH`, `SSL_CERT_DIR`, or `SSL_CERT_FILE` environment
 variables, in which case this function will always return the value of the first
-of these variables that is set (whether the path exists or not).
+of these variables that is set (whether the path exists or not). If
+`JULIA_SSL_CA_ROOTS_PATH` is set to the empty string, then the other variables
+are ignored (as if unset); if the other variables are set to the empty string,
+they behave is if they are not set.
 
 ### ca_roots_path
 
@@ -56,7 +59,10 @@ libraries which _require_ a path to a file or directory for root certificates.
 The default value returned by `ca_roots_path()` may be overridden by setting the
 `JULIA_SSL_CA_ROOTS_PATH`, `SSL_CERT_DIR`, or `SSL_CERT_FILE` environment
 variables, in which case this function will always return the value of the first
-of these variables that is set (whether the path exists or not).
+of these variables that is set (whether the path exists or not). If
+`JULIA_SSL_CA_ROOTS_PATH` is set to the empty string, then the other variables
+are ignored (as if unset); if the other variables are set to the empty string,
+they behave is if they are not set.
 
 ### ssh_dir
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,15 @@ include("setup.jl")
             @test ca_roots_path() == unset[2]
             clear_env()
         end
+        for (i, var) in enumerate(CA_ROOTS_VARS)
+            ENV[var] = string(i)
+        end
+        @test ca_roots() == "1"
+        @test ca_roots_path() == "1"
+        ENV[CA_ROOTS_VARS[1]] = ""
+        @test ca_roots() == unset[1]
+        @test ca_roots_path() == unset[2]
+        clear_env()
     end
 end
 


### PR DESCRIPTION
Part of addressing https://github.com/JuliaLang/julia/issues/38691.