### PR TITLE
Add the `NetworkOptions.__diagnostics__()` function

### DIFF
--- a/src/NetworkOptions.jl
+++ b/src/NetworkOptions.jl
@@ -1,6 +1,7 @@
 module NetworkOptions
 
 include("ca_roots.jl")
+include("diagnostics.jl")
 include("ssh_options.jl")
 include("verify_host.jl")
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,0 +1,50 @@
+# NetworkOptions.__diagnostics__()
+function __diagnostics__(io::IO)
+    indent = "  "
+    name_list = [
+        "JULIA_ALWAYS_VERIFY_HOSTS",
+        "JULIA_NO_VERIFY_HOSTS",
+        "JULIA_SSH_NO_VERIFY_HOSTS",
+        "JULIA_SSL_CA_ROOTS_PATH",
+        "JULIA_SSL_NO_VERIFY_HOSTS",
+        "SSH_DIR",
+        "SSH_KEY_NAME",
+        "SSH_KEY_PASS",
+        "SSH_KEY_PATH",
+        "SSH_KNOWN_HOSTS_FILES",
+        "SSH_PUB_KEY_PATH",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+    ]
+    lines_to_print = Tuple{String, String}[]
+    environment = ENV
+    for name in name_list
+        if haskey(environment, name)
+            value = environment[name]
+            if isempty(value)
+                description = "[empty]"
+            else
+                if isempty(strip(value))
+                    description = "[whitespace]"
+                else
+                    description = "***"
+                end
+            end
+            line = (name, description)
+            push!(lines_to_print, line)
+        end
+    end
+    if isempty(lines_to_print)
+        println(io, "Relevant environment variables: [none]")
+    else
+        println(io, "Relevant environment variables:")
+        all_names = getindex.(lines_to_print, Ref(1))
+        max_name_length = maximum(length.(all_names))
+        name_pad_length = length(indent) + max_name_length + 1
+        for (name, description) in lines_to_print
+            name_padded = rpad("$(indent)$(name):", name_pad_length)
+            println(io, "$(name_padded) $(description)")
+        end
+    end
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -316,4 +316,12 @@ end
     end
 end
 
+@testset "__diagnostics__()" begin
+    # check that `NetworkOptions.__diagnostics__(io)` doesn't error, produces some output
+    buf = PipeBuffer()
+    NetworkOptions.__diagnostics__(buf)
+    output = read(buf, String)
+    @test occursin("Relevant environment variables:", output)
+end
+
 reset_env()


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/43834#issuecomment-1034211488 for context.

---

Example output if no relevant environment variables are set:

```
julia> NetworkOptions.__diagnostics__(stdout)
Relevant environment variables: [none]
```

Example output if one or more relevant environment variables are set:

```
julia> NetworkOptions.__diagnostics__(stdout)
Relevant environment variables:
  SSH_KEY_PASS:  ***
  SSL_CERT_DIR:  ***
  SSL_CERT_FILE: ***
```