### PR TITLE
[CI] Codecov: disable the inline Codecov annotations in the "Files Changed" view of a pull request

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+    annotations: false # Disable the annotations in the "Files Changed" view of a pull request.


### PR DESCRIPTION
Same motivation as https://github.com/JuliaLang/Pkg.jl/pull/2577

The Codecov inline annotations make the diff much harder to read.