### PR TITLE
Use human-readable title in the docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# NetworkOptions
+# Network Options
 
 ```@docs
 NetworkOptions.ca_roots


### PR DESCRIPTION
This matches the convention used in other similar stdlib packages, e.g.:

- [DelimitedFiles](https://github.com/JuliaData/DelimitedFiles.jl/blob/main@{2023-06-29}/docs/src/index.md) → [Delimited Files](https://docs.julialang.org/en/v1/stdlib/DelimitedFiles/)
- [LazyArtifacts](https://github.com/JuliaLang/julia/blob/master@{2023-06-29}/stdlib/LazyArtifacts/docs/src/index.md) → [Lazy Artifacts](https://docs.julialang.org/en/v1/stdlib/LazyArtifacts/)
- [LinearAlgebra](https://github.com/JuliaLang/julia/blob/master@{2023-06-29}/stdlib/LinearAlgebra/docs/src/index.md) → [Linear Algebra](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/)
- [SharedArrays](https://github.com/JuliaLang/julia/blob/master@{2023-06-29}/stdlib/SharedArrays/docs/src/index.md) → [Shared Arrays](https://docs.julialang.org/en/v1/stdlib/SharedArrays/)
- [SparseArrays](https://github.com/JuliaSparse/SparseArrays.jl/blob/main@{2023-06-29}/docs/src/index.md) → [Sparse Arrays](https://docs.julialang.org/en/v1/stdlib/SparseArrays/) 
