### PR TITLE
Reset BUNDLED_KNOWN_HOSTS_FILE in case we serialized a value due to precompilation

### DIFF
--- a/src/ssh_options.jl
+++ b/src/ssh_options.jl
@@ -156,8 +156,8 @@ function bundled_known_hosts()
             write(io, BUNDLED_KNOWN_HOSTS)
             close(io)
         end
+        return file::String
     end
-    return file::String
 end
 
 function __init__()


### PR DESCRIPTION
Fixes the issue observed in https://github.com/JuliaLang/julia/pull/51046#issuecomment-1709280026

Downloads.jl uses a precompilation statement and we bake into the system image a temporary filename
that only exists during precompilation.


