### PR TITLE
clear out cache variables when loading the package

### DIFF
--- a/src/NetworkOptions.jl
+++ b/src/NetworkOptions.jl
@@ -4,4 +4,10 @@ include("ca_roots.jl")
 include("ssh_options.jl")
 include("verify_host.jl")
 
+function __init__()
+    SYSTEM_CA_ROOTS[] = nothing
+    BUNDLED_KNOWN_HOSTS_FILE[] = nothing
+    empty!(ENV_HOST_PATTERN_CACHE)
+end
+
 end # module

--- a/src/ssh_options.jl
+++ b/src/ssh_options.jl
@@ -160,13 +160,6 @@ function bundled_known_hosts()
     end
 end
 
-function __init__()
-    # Reset in case we serialized a value here.
-    lock(BUNDLED_KNOWN_HOSTS_LOCK) do
-        BUNDLED_KNOWN_HOSTS_FILE[] = nothing
-    end
-end
-
 const BUNDLED_KNOWN_HOSTS = """
 github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
 github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl


### PR DESCRIPTION
This is required on 1.10 where Downloads and NetworkOptions are in the sysimage (see https://github.com/JuliaLang/julia/issues/53339) but it seems like a good idea here anyway in case someone adds a precompile workload to this package.

I thought about using `atexit` hooks for this to avoid the `__init__` but that would require https://github.com/JuliaLang/julia/pull/51849 (AFAIU) and we don't have that on 1.10.