### PR TITLE
Enable OpenSSL certificates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NetworkOptions"
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 authors = ["Stefan Karpinski <stefan@karpinski.org> and contributors"]
-version = "1.2.0"
+version = "1.3.0"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
I'm working on replacing MbedTLS by OpenSSL in Julia. See https://github.com/JuliaLang/julia/pull/56708. This allows (requires?) enabling OpenSSL certificates.
